### PR TITLE
Step0fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ It is your first day as a SWE at a trading firm that specializes in trading Oleo
 - Use the logging library to help you understand what is happening in the code.
 
 ## Instructions
-- [ ] Add yourself to the `progress.md` file on the main branch. 
 - [ ] Fork this repo for yourself
 - [ ] Clone the repo locally (Ensure you are on Branch 0!)
 - [ ] Navigate to the repository root and use `mkdir build && cd build` to create a build directory and navigate to it

--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,7 +16,6 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
-    this->pendingTrades.clear();
     return 0;
 }
 
@@ -28,4 +27,3 @@ int RiskTracker::addTrade(Trade trade) {
 float RiskTracker::getRisk() {
     return this->totalRisk;
 }
-

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,13 +28,3 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
-
-TEST(TradeRiskTrackerTest, MultipleRiskUpdate) {
-    std::vector<Trade> trackedTrades;
-    RiskTracker riskTracker(0, trackedTrades);
-    riskTracker.addTrade(Trade(10, true, 1.5));
-    riskTracker.updateRisk();
-    float initialRisk = riskTracker.getRisk();
-    riskTracker.updateRisk();
-    EXPECT_NEAR(riskTracker.getRisk(), initialRisk, 1e-4);
-}


### PR DESCRIPTION
The bug is that we should clear pending trades after calculating the risk
Otherwise it might accumulate the risk, causing wrong calculation of the risk.

The new test I created allows calling updateRisk() multiple times without adding new trades won't change the risk after the first update.
